### PR TITLE
Basic authentication domain

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ServiceAgents Toolbox
 
+## 4.1.0
+
+- Added optional domain setting for Basic authentication
+
 ## 4.0.3
 
 - Fixed Error object changes

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Toolbox for ServiceAgents in ASP.NET Core.
 
-This readme is applicable for toolbox version 4.0.x
+This readme is applicable for toolbox version 4.1.x
 
 ## Table of Contents
 
@@ -28,7 +28,7 @@ To add the toolbox to a project, you add the package to the project.json :
 
 ``` json
     "dependencies": {
-        "Digipolis.ServiceAgents":  "4.0.2"
+        "Digipolis.ServiceAgents":  "4.1.0"
     }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -298,7 +298,7 @@ See the SampleApi for more info.
 With the Basic scheme the authentication is done through use of a Basic Authentication header.
 
     Authorization Basic yyy
-where yyy is the base 64 encoded username and password.  
+where yyy is the base 64 encoded username and password, with username containing an optional domain
 
 Basic authentication can only be used with an "https" scheme except for the **Development** environment!
 
@@ -314,6 +314,7 @@ The **user name** and **password** can be entered in the settings.
       "Path": "api",
       "Port": "5001",
       "Scheme": "https",
+      "BasicAuthDomain": "domain",
       "BasicAuthUserName": "userName",
       "BasicAuthPassword": "password"
     }
@@ -329,6 +330,7 @@ to alter the values of the service settings after they have been loaded from the
     }, serviceAgentSettings =>
     {
         var settings = serviceAgentSettings.Services.Single(s => s.Key == nameof(TestAgent)).Value; 
+		settings.BasicAuthDomain = "domainfromcode"
         settings.BasicAuthPassword = "userNamefromcode";
         settings.BasicAuthUserName = "passwordfromcode";
     }, null);

--- a/src/Digipolis.ServiceAgents/HttpClientFactory.cs
+++ b/src/Digipolis.ServiceAgents/HttpClientFactory.cs
@@ -64,7 +64,9 @@ namespace Digipolis.ServiceAgents
             if (IsDevelopmentEnvironment() == false && settings.Scheme != HttpSchema.Https)
                 throw new ServiceAgentException($"Failed to set Basic Authentication header on service agent for host: '{settings.Host}', the actual scheme is '{settings.Scheme}' and should be 'https'!");
 
-            var headerValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{settings.BasicAuthUserName}:{settings.BasicAuthPassword}"));
+            string username = settings.BasicAuthUserName;
+            if (!string.IsNullOrEmpty(settings.BasicAuthDomain)) username = $"{settings.BasicAuthDomain}\\{settings.BasicAuthUserName}";
+            var headerValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{settings.BasicAuthPassword}"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthScheme.Basic, headerValue);
         }
 

--- a/src/Digipolis.ServiceAgents/Settings/ServiceSettings.cs
+++ b/src/Digipolis.ServiceAgents/Settings/ServiceSettings.cs
@@ -19,6 +19,11 @@ namespace Digipolis.ServiceAgents.Settings
         public string OAuthScope { get; set; }
 
         /// <summary>
+        /// The optional domain used for basic authentication scheme.
+        /// </summary>
+        public string BasicAuthDomain { get; set; }
+
+        /// <summary>
         /// The user name used for basic authentication scheme.
         /// </summary>
         public string BasicAuthUserName { get; set; }

--- a/src/Digipolis.ServiceAgents/project.json
+++ b/src/Digipolis.ServiceAgents/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Toolbox for ServiceAgents in ASP.NET Core.",
   "authors": [ "digipolis.be" ],
   "packOptions": {

--- a/test/Digipolis.ServiceAgents.UnitTests/HttpClientFactoryTests/CreateClientTests.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/HttpClientFactoryTests/CreateClientTests.cs
@@ -60,6 +60,20 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
         }
 
         [Fact]
+        public void CreateClientWithBasicAuthenticationAndDomain()
+        {
+            var serviceAgentSettings = new ServiceAgentSettings { };
+            var settings = new ServiceSettings { AuthScheme = AuthScheme.Basic, BasicAuthDomain = "ICA", BasicAuthUserName = "Aladdin", BasicAuthPassword = "OpenSesame", Host = "test.be", Path = "api" };
+            var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
+
+            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+
+            Assert.NotNull(client);
+            Assert.Equal(AuthScheme.Basic, client.DefaultRequestHeaders.Authorization.Scheme);
+            Assert.Equal("SUNBXEFsYWRkaW46T3BlblNlc2FtZQ==", client.DefaultRequestHeaders.Authorization.Parameter);
+        }
+
+        [Fact]
         public void CreateClientWithOAuthClientCredentials()
         {
             var serviceAgentSettings = new ServiceAgentSettings { };


### PR DESCRIPTION
Basic authentication requiring a domain would contain a backslash for the username property in the json config file. This doesn't play nice with AppConfig. An optional item was added in the ServiceSettings to specify a domain for a user.