### PR TITLE
Json parse error exception

### DIFF
--- a/src/Digipolis.ServiceAgents/AgentBase.cs
+++ b/src/Digipolis.ServiceAgents/AgentBase.cs
@@ -91,7 +91,7 @@ namespace Digipolis.ServiceAgents
                 {
                     Title = "Json parse error exception.",
                     Status = (int)response.StatusCode,
-                    ExtraParameters = new Dictionary<string, IEnumerable<string>> { { "json", new List<string> { errorJson } } }
+                    ExtraParameters = new Dictionary<string, IEnumerable<string>> { { "response", new List<string> { errorJson } } }
                 };
             }
 

--- a/src/Digipolis.ServiceAgents/AgentBase.cs
+++ b/src/Digipolis.ServiceAgents/AgentBase.cs
@@ -84,14 +84,15 @@ namespace Digipolis.ServiceAgents
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                OnParseJsonErrorException(ex, response);
                 errorResponse = new Error
                 {
                     Title = "Json parse error exception.",
-                    Status = (int)response.StatusCode
+                    Status = (int)response.StatusCode,
+                    ExtraParameters = new Dictionary<string, IEnumerable<string>> { { "json", new List<string> { errorJson } } }
                 };
-                errorResponse.ExtraParameters?.Add("json", new List<string> { errorJson });
             }
 
             // Throw proper exception based on HTTP status
@@ -126,6 +127,8 @@ namespace Digipolis.ServiceAgents
                     messages: extraParameters);
             }
         }
+
+        protected virtual void OnParseJsonErrorException(Exception ex, HttpResponseMessage response) { }
 
         protected async Task<T> GetAsync<T>(string requestUri)
         {


### PR DESCRIPTION
To enable Better logging in apps using this package:
ParseJsonError: fixed exception handling - ExtraParameters was always null
OnParseJsonErrorException: added hook for custom exception handling
Changed key from "json" to "response": if exceptions happen when deserialising, possibly content isn't JSON.
