### PR TITLE
AgentBase - initialize _client on first use

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # ServiceAgents Toolbox
+
+## 6.0.4
+- AgentBase: initialization of _client (HttpClient) happens on first use instead of during constructor execution to avoid unnecessary calls to retrieve an access token for OAuth-authentication scheme
+
 ## 6.0.3
 - ParseJsonError: fixed Exception handling - ExtraParameters always null
 - OnParseJsonErrorException: Added hook for custom exception handling

--- a/src/Digipolis.ServiceAgents/Digipolis.ServiceAgents.csproj
+++ b/src/Digipolis.ServiceAgents/Digipolis.ServiceAgents.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Toolbox for ServiceAgents in ASP.NET Core.</Description>
-    <VersionPrefix>6.0.3</VersionPrefix>
+    <VersionPrefix>6.0.4</VersionPrefix>
     <Authors>digipolis.be</Authors>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Digipolis.ServiceAgents</AssemblyName>

--- a/src/Digipolis.ServiceAgents/HttpClientFactory.cs
+++ b/src/Digipolis.ServiceAgents/HttpClientFactory.cs
@@ -20,7 +20,7 @@ namespace Digipolis.ServiceAgents
             _serviceProvider = serviceProvider;           
         }
 
-        public HttpClient CreateClient(ServiceAgentSettings serviceAgentSettings, ServiceSettings settings)
+        public HttpClient CreateClient(ServiceSettings settings)
         {
             var client = new HttpClient
             {

--- a/src/Digipolis.ServiceAgents/IHttpClientFactory.cs
+++ b/src/Digipolis.ServiceAgents/IHttpClientFactory.cs
@@ -5,6 +5,6 @@ namespace Digipolis.ServiceAgents
 {
     public interface IHttpClientFactory
     {
-        HttpClient CreateClient(ServiceAgentSettings serviceAgentSettings, ServiceSettings settings);
+        HttpClient CreateClient(ServiceSettings settings);
     }
 }

--- a/src/Digipolis.ServiceAgents/Settings/AuthScheme.cs
+++ b/src/Digipolis.ServiceAgents/Settings/AuthScheme.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Digipolis.ServiceAgents.Settings
+﻿namespace Digipolis.ServiceAgents.Settings
 {
     public class AuthScheme
     {

--- a/src/Digipolis.ServiceAgents/Settings/Defaults.cs
+++ b/src/Digipolis.ServiceAgents/Settings/Defaults.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Digipolis.ServiceAgents.Settings
+﻿namespace Digipolis.ServiceAgents.Settings
 {
     public class Defaults
     {

--- a/src/Digipolis.ServiceAgents/Settings/ServiceSettingsConfigReader.cs
+++ b/src/Digipolis.ServiceAgents/Settings/ServiceSettingsConfigReader.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using Digipolis.Common.Validation;
 
 namespace Digipolis.ServiceAgents.Settings
 {

--- a/test/Digipolis.ServiceAgents.UnitTests/BaseClass/AgentBaseTests.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/BaseClass/AgentBaseTests.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Digipolis.Errors.Exceptions;
+using Digipolis.ServiceAgents.Settings;
+using Digipolis.ServiceAgents.UnitTests.Utilities;
+using Microsoft.Extensions.Options;
 using Moq;
+using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Net;
-using Digipolis.ServiceAgents.Settings;
-using Digipolis.ServiceAgents.UnitTests.Utilities;
-using Xunit;
 using System.Net.Http;
-using Digipolis.Errors.Exceptions;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Xunit;
 
 namespace Digipolis.ServiceAgents.UnitTests.BaseClass
 {

--- a/test/Digipolis.ServiceAgents.UnitTests/HttpClientFactoryTests/CreateClientTests.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/HttpClientFactoryTests/CreateClientTests.cs
@@ -21,7 +21,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { Scheme = HttpSchema.Http, Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal("http://test.be/api/", client.BaseAddress.AbsoluteUri);
@@ -36,7 +36,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.Bearer, Scheme = HttpSchema.Http, Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal("http://test.be/api/", client.BaseAddress.AbsoluteUri);
@@ -52,7 +52,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.Basic, BasicAuthUserName = "Aladdin", BasicAuthPassword = "OpenSesame", Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal(AuthScheme.Basic, client.DefaultRequestHeaders.Authorization.Scheme);
@@ -66,7 +66,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.Basic, BasicAuthDomain = "ICA", BasicAuthUserName = "Aladdin", BasicAuthPassword = "OpenSesame", Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal(AuthScheme.Basic, client.DefaultRequestHeaders.Authorization.Scheme);
@@ -80,7 +80,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.OAuthClientCredentials, OAuthClientId = "clientId", OAuthClientSecret = "clientSecret", Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal(AuthScheme.Bearer, client.DefaultRequestHeaders.Authorization.Scheme);
@@ -94,7 +94,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.Basic, BasicAuthUserName = "Aladdin", BasicAuthPassword = "OpenSesame", Scheme = HttpSchema.Http, Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            Assert.Throws<ServiceAgentException>(() => clientFactory.CreateClient(serviceAgentSettings, settings));
+            Assert.Throws<ServiceAgentException>(() => clientFactory.CreateClient(settings));
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { AuthScheme = AuthScheme.Basic, BasicAuthUserName = "Aladdin", BasicAuthPassword = "OpenSesame", Scheme = HttpSchema.Http, Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings, isDevelopmentEnvironment: true));
 
-            clientFactory.CreateClient(serviceAgentSettings, settings);
+            clientFactory.CreateClient(settings);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             HttpClient passedClient = null;
             clientFactory.AfterClientCreated += (sp, c) => passedClient = c;
 
-            clientFactory.CreateClient(serviceAgentSettings, settings);
+            clientFactory.CreateClient(settings);
 
             Assert.NotNull(passedClient);
         }
@@ -133,7 +133,7 @@ namespace Digipolis.ServiceAgents.UnitTests.HttpClientFactoryTests
             var settings = new ServiceSettings { Headers = headers, Scheme = HttpSchema.Http, Host = "test.be", Path = "api" };
             var clientFactory = new HttpClientFactory(CreateServiceProvider(settings));
 
-            var client = clientFactory.CreateClient(serviceAgentSettings, settings);
+            var client = clientFactory.CreateClient(settings);
 
             Assert.NotNull(client);
             Assert.Equal("localapikey", client.DefaultRequestHeaders.First(h => h.Key == "api-key").Value.First());

--- a/test/Digipolis.ServiceAgents.UnitTests/Startup/AddServiceAgentsTests.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/Startup/AddServiceAgentsTests.cs
@@ -67,7 +67,7 @@ namespace Digipolis.ServiceAgents.UnitTests.Startup
 
             //Manually call the CreateClient on the factory (this normally happens when the service agent gets resolved
             var factory = registration.ImplementationFactory.Invoke(null) as HttpClientFactory;
-            factory.CreateClient(serviceAgentSettings, new ServiceSettings { Host = "test.be" });
+            factory.CreateClient(new ServiceSettings { Host = "test.be" });
 
             Assert.NotNull(passedClient);
         }

--- a/test/Digipolis.ServiceAgents.UnitTests/Startup/AddSingleServiceAgentTests.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/Startup/AddSingleServiceAgentTests.cs
@@ -50,7 +50,7 @@ namespace Digipolis.ServiceAgents.UnitTests.Startup
 
             //Manually call the CreateClient on the factory (this normally happens when the service agent gets resolved
             var factory = registration.ImplementationFactory.Invoke(null) as HttpClientFactory;
-            factory.CreateClient(serviceAgentSettings, new ServiceSettings { Host = "test.be" });
+            factory.CreateClient(new ServiceSettings { Host = "test.be" });
 
             Assert.NotNull(passedClient);
         }

--- a/test/Digipolis.ServiceAgents.UnitTests/Utilities/TestAgent.cs
+++ b/test/Digipolis.ServiceAgents.UnitTests/Utilities/TestAgent.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Digipolis.ServiceAgents.Settings;
+using Microsoft.Extensions.Options;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Digipolis.ServiceAgents.Settings;
 
 namespace Digipolis.ServiceAgents.UnitTests.Utilities
 {


### PR DESCRIPTION
AgentBase - initialize _client on first use instead off in constructor to avoid retrieving OAuth access-token during DI resolving + clean usings